### PR TITLE
WebRoot parsing BugFix

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -179,6 +179,7 @@ function vf_validate_options($options) {
 function vf_validate_url($url) {
   $html = vf_rest($url);
   $formats = array(
+  	 '"WebRoot": "',     // 2.2  	BUGFIX
   	 '"WebRoot":"',     // 2.2
   	 '\'WebRoot\' : "', // 2.0.18.13+ and 2.1.1+
   	 'WebRoot" value="' // legacy


### PR DESCRIPTION
After installing this plugin we've encountered a problem that our forum's URL couldn't be validated. So we started to investigate what's going wrong.
In our case we've found out that html body requested were correct but  Webroot parameter as all parameters returned were separated with space.
To fix this I've added another format to   vf_validate_url    function make it more agile. It's just  one more space but it works:)
Hope it helps somebody too.
