### PR TITLE
update latest WordPress tested version to 4.9.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: VanillaForums
 Tags: forum, forums, community, vanilla, vanilla forums, single sign-on, sso, widgets, widget, embed, embedded forum
 Requires at least: 3
-Tested up to: 4.2.2
-Stable tag: 1.1.17
+Tested up to: 4.9.5
+Stable tag: 1.1.18
 
 == Description ==
 


### PR DESCRIPTION
Updated the Tested up to: to remove the notification that was displaying under [https://en-ca.wordpress.org/plugins/vanilla-forums/](https://en-ca.wordpress.org/plugins/vanilla-forums/)
