### PR TITLE
Return correct headers for JSON and Javascript responses.

### DIFF
--- a/functions.jsconnect.php
+++ b/functions.jsconnect.php
@@ -80,12 +80,14 @@ function writeJsConnect($user, $request, $clientID, $secret, $secure = true) {
     }
 
     $json = json_encode($result);
+    if (!headers_sent()) {
+        $contentType = jsConnectContentType($request);
+        header($contentType, true);
+    }
 
     if (isset($request['callback'])) {
-        safeHeader('Content-Type: application/javascript; charset=utf-8', true);
         echo "{$request['callback']}($json)";
     } else {
-        safeHeader('Content-Type: application/json; charset=utf-8', true);
         echo $json;
     }
 }
@@ -173,4 +175,16 @@ function jsSSOString($user, $clientID, $secret) {
 
     $result = "$string $hash $timestamp hmacsha1";
     return $result;
+}
+
+/**
+ * Based on a jsConnect request, determine the proper response content type.
+ *
+ * @param array $request
+ * @return string
+ */
+function jsConnectContentType(array $request) {
+    $isJsonp = isset($request["callback"]);
+    $contentType = $isJsonp ? "Content-Type: application/javascript; charset=utf-8" : "Content-Type: application/json; charset=utf-8";
+    return $contentType;
 }

--- a/functions.jsconnect.php
+++ b/functions.jsconnect.php
@@ -82,8 +82,10 @@ function writeJsConnect($user, $request, $clientID, $secret, $secure = true) {
     $json = json_encode($result);
 
     if (isset($request['callback'])) {
+        safeHeader('Content-Type: application/javascript; charset=utf-8', true);
         echo "{$request['callback']}($json)";
     } else {
+        safeHeader('Content-Type: application/json; charset=utf-8', true);
         echo $json;
     }
 }


### PR DESCRIPTION
Presently when trying to use WordPress to authenticate SSO connections for forums we are not returning the proper content-type headers. This PR will fix it. 

This will possibly solve this issue: https://github.com/vanilla/support/issues/1073