### PR TITLE
Bumping the version to match the next available tag.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Vanilla Forums
 Plugin URI: https://vanillaforums.com
 Description: Integrates Vanilla Forums with WordPress: embedded blog comments, embedded forum, single sign on, and WordPress widgets.
-Version: 1.2
+Version: 1.2.2
 Author: Vanilla Forums
 Author URI: https://vanillaforums.com
 
@@ -71,6 +71,8 @@ ChangeLog:
 - Update jsConnect client library
 1.2.1
 - Pass `PHP_QUERY_RFC1738` as `enc_type` argument to `http_build_query()` when building the JSConnect response.
+1.2.2
+- Bumping up the version, for Thanksgiving.
 
 Copyright 2010-2019 Vanilla Forums Inc
 This file is part of the Vanilla Forums plugin for WordPress.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: VanillaForums
 Tags: forum, forums, community, vanilla, vanilla forums, single sign-on, sso, widgets, widget, embed, embedded forum
 Requires at least: 3
 Tested up to: 5.3
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 
 == Description ==
 


### PR DESCRIPTION
The Tags were somehow ahead of the version in the plugin.php and the readme. This PR will fix that.