### PR TITLE
Bump up the version number.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: VanillaForums
 Tags: forum, forums, community, vanilla, vanilla forums, single sign-on, sso, widgets, widget, embed, embedded forum
 Requires at least: 3
 Tested up to: 5.3
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 
 == Description ==
 


### PR DESCRIPTION
Recent changes to the Vanilla Wordpress plugin requires that we bump up the version.