### PR TITLE
Bump up the version of the Wordpress Plugin.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -73,6 +73,8 @@ ChangeLog:
 - Pass `PHP_QUERY_RFC1738` as `enc_type` argument to `http_build_query()` when building the JSConnect response.
 1.2.2
 - Bumping up the version, for Thanksgiving.
+1.3.0
+- Upgrading JSConnect V3
 
 Copyright 2010-2019 Vanilla Forums Inc
 This file is part of the Vanilla Forums plugin for WordPress.

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Vanilla Forums
 Plugin URI: https://vanillaforums.com
 Description: Integrates Vanilla Forums with WordPress: embedded blog comments, embedded forum, single sign on, and WordPress widgets.
-Version: 1.2.2
+Version: 1.3.0
 Author: Vanilla Forums
 Author URI: https://vanillaforums.com
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: VanillaForums
 Tags: forum, forums, community, vanilla, vanilla forums, single sign-on, sso, widgets, widget, embed, embedded forum
 Requires at least: 3
 Tested up to: 5.3
-Stable tag: 1.2.3
+Stable tag: 1.3.0
 
 == Description ==
 


### PR DESCRIPTION
This puts the version at 1.3.0 and puts the version in the doc block of the Plugin and in the Readme.